### PR TITLE
Seed Identity Roles for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # SpeakingInBitsWeb
+
+## Logging as instructor in development
+To log in as an instructor in development, you can use the 
+following credentials:
+- Username: `DefaultInstructor`
+- Password: `Programming01#`
+
+*Note*: This account is only available in the development environment
+and seeded within `/Models/SeedData.cs`.

--- a/SpeakingInBitsWeb.slnx
+++ b/SpeakingInBitsWeb.slnx
@@ -1,3 +1,6 @@
 <Solution>
+  <Folder Name="/Solution Items/">
+    <File Path="README.md" />
+  </Folder>
   <Project Path="SpeakingInBitsWeb/SpeakingInBitsWeb.csproj" />
 </Solution>

--- a/SpeakingInBitsWeb/Models/SeedData.cs
+++ b/SpeakingInBitsWeb/Models/SeedData.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace SpeakingInBitsWeb.Models
+{
+    /// <summary>
+    /// Provides methods for seeding initial data into the database.
+    /// </summary>
+    public static class SeedData
+    {
+        /// <summary>
+        /// Creates all necessary roles in the system if they don't already exist.
+        /// </summary>
+        /// <param name="roleManager">The role manager service.</param>
+        public static async Task CreateRolesAsync(RoleManager<IdentityRole> roleManager)
+        {
+            string[] roles = ["Instructor", "Student"];
+
+            foreach (var role in roles)
+            {
+                if (!await roleManager.RoleExistsAsync(role))
+                {
+                    await roleManager.CreateAsync(new IdentityRole(role));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a default instructor user if one doesn't already exist.
+        /// </summary>
+        /// <param name="userManager">The user manager service.</param>
+        public static async Task CreateDefaultUserAsync(UserManager<ApplicationUser> userManager)
+        {
+            string defaultEmail = "instructor@example.com";
+            ApplicationUser? defaultUser = await userManager.FindByEmailAsync(defaultEmail);
+
+            if (defaultUser == null)
+            {
+                ApplicationUser newUser = new()
+                {
+                    UserName = "DefaultInstructor",
+                    Email = defaultEmail,
+                    EmailConfirmed = true,
+                    FirstName = "Default",
+                    LastName = "Instructor"
+                };
+
+                // Ensure password meets password strength requirements
+                IdentityResult result = await userManager.CreateAsync(newUser, "Programming01#");
+
+                if (result.Succeeded)
+                {
+                    await userManager.AddToRoleAsync(newUser, "Instructor");
+                }
+            }
+        }
+    }
+}

--- a/SpeakingInBitsWeb/Program.cs
+++ b/SpeakingInBitsWeb/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
+    .AddRoles<IdentityRole>() // Add role support to Identity
     .AddEntityFrameworkStores<ApplicationDbContext>();
 builder.Services.AddControllersWithViews();
 
@@ -43,5 +44,16 @@ app.MapControllerRoute(
 
 app.MapRazorPages()
    .WithStaticAssets();
+
+#if DEBUG
+using (var scope = app.Services.CreateScope())
+{
+    var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+    await SeedData.CreateRolesAsync(roleManager);
+    await SeedData.CreateDefaultUserAsync(userManager);
+}
+#endif
 
 app.Run();


### PR DESCRIPTION
Closes #11
Closes #4 

This pull request introduces initial support for role-based identity and seeding of a default instructor user in the development environment. It adds a `SeedData` utility for database seeding, updates the application startup to seed roles and a default user in development, and improves documentation for developers.

**Role-based identity and user seeding:**

* Added a new `SeedData` class in `SpeakingInBitsWeb/Models/SeedData.cs` that seeds default roles ("Instructor", "Student") and a default instructor user with username `DefaultInstructor` and password `Programming01#` in development.
* Updated `SpeakingInBitsWeb/Program.cs` to add role support to ASP.NET Identity and to call the seeding methods during application startup in development builds. [[1]](diffhunk://#diff-c4d17a3e996705e333df139c3ede2a9438bd683b8b723574a809c8d4efb40d3aR15) [[2]](diffhunk://#diff-c4d17a3e996705e333df139c3ede2a9438bd683b8b723574a809c8d4efb40d3aR48-R58)

**Developer documentation and solution structure:**

* Updated `README.md` with instructions for logging in as the default instructor in development and noted the credentials are seeded via `/Models/SeedData.cs`.
* Added `README.md` as a solution item in `SpeakingInBitsWeb.slnx` for easier access from the solution explorer.